### PR TITLE
Add model training utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,14 @@ This downloads weekly prices from Yahoo! Finance and writes a table of
 lagged factors with graph metrics.
 
 
+
+## Model training
+
+After generating the feature dataset you can train the XGBoost model and generate trading signals:
+
+```bash
+python -m portfolio_dashboard.train_model --data features.parquet \
+    --model-out xgb_model.pkl --pred-out predictions.csv
+```
+
+Optional SHAP values can be saved with `--shap-out shap.csv`.

--- a/portfolio_dashboard/__init__.py
+++ b/portfolio_dashboard/__init__.py
@@ -1,0 +1,10 @@
+"""PortfolioDashboard package."""
+
+from .pipeline import build_feature_dataset
+from .model_utils import (
+    prepare_features,
+    train_xgb_classifier,
+    generate_signals,
+    save_model,
+    load_model,
+)

--- a/portfolio_dashboard/config.py
+++ b/portfolio_dashboard/config.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+"""Configuration constants for model training."""
+
+XGB_PARAMS = {
+    "max_depth": 3,
+    "learning_rate": 0.1,
+    "n_estimators": 200,
+    "subsample": 0.8,
+    "colsample_bytree": 0.8,
+    "objective": "binary:logistic",
+    "eval_metric": "logloss",
+    "random_state": 42,
+}
+
+SIGNAL_UPPER_Q = 0.9
+SIGNAL_LOWER_Q = 0.1

--- a/portfolio_dashboard/model_utils.py
+++ b/portfolio_dashboard/model_utils.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+"""Helper functions for model training and signal generation."""
+
+from typing import Iterable, Tuple
+import pickle
+
+import numpy as np
+import pandas as pd
+from sklearn.model_selection import TimeSeriesSplit
+from xgboost import XGBClassifier
+
+from .config import XGB_PARAMS, SIGNAL_LOWER_Q, SIGNAL_UPPER_Q
+
+
+def create_target(df: pd.DataFrame, horizon: int = 1) -> pd.Series:
+    """Return future percentage return for each stock."""
+    return (
+        df["Close"].groupby(level="Ticker").pct_change(horizon).shift(-horizon)
+    )
+
+
+def prepare_features(df: pd.DataFrame, horizon: int = 1) -> Tuple[pd.DataFrame, pd.Series]:
+    """Create training features ``X`` and binary target ``y``."""
+    target = create_target(df, horizon)
+    feature_cols = [c for c in df.columns if c != "Close"]
+    X = df[feature_cols].copy()
+    X = X.loc[X.index.intersection(target.dropna().index)]
+    y = (target.loc[X.index] > 0).astype(int)
+    return X, y
+
+
+def train_xgb_classifier(
+    X: pd.DataFrame,
+    y: pd.Series,
+    params: dict | None = None,
+    n_splits: int = 3,
+) -> XGBClassifier:
+    """Train an XGBoost classifier using expanding-window CV."""
+    params = params or XGB_PARAMS
+    tscv = TimeSeriesSplit(n_splits=n_splits)
+    best_model: XGBClassifier | None = None
+    best_score = -np.inf
+    for train_idx, val_idx in tscv.split(X):
+        X_train, X_val = X.iloc[train_idx], X.iloc[val_idx]
+        y_train, y_val = y.iloc[train_idx], y.iloc[val_idx]
+        model = XGBClassifier(**params)
+        model.fit(
+            X_train,
+            y_train,
+            eval_set=[(X_val, y_val)],
+            verbose=False,
+        )
+        score = model.best_score if hasattr(model, "best_score") else model.score(X_val, y_val)
+        if score > best_score:
+            best_score = score
+            best_model = model
+    assert best_model is not None
+    best_model.fit(X, y)
+    return best_model
+
+
+def save_model(model: XGBClassifier, path: str) -> None:
+    with open(path, "wb") as f:
+        pickle.dump(model, f)
+
+
+def load_model(path: str) -> XGBClassifier:
+    with open(path, "rb") as f:
+        return pickle.load(f)
+
+
+def generate_signals(
+    probs: pd.Series,
+    lower_q: float = SIGNAL_LOWER_Q,
+    upper_q: float = SIGNAL_UPPER_Q,
+) -> pd.DataFrame:
+    """Return DataFrame with probability and long/short signal."""
+    signals = pd.DataFrame({"prob_up": probs})
+    lower = probs.quantile(lower_q)
+    upper = probs.quantile(upper_q)
+    signals["signal"] = 0
+    signals.loc[probs >= upper, "signal"] = 1
+    signals.loc[probs <= lower, "signal"] = -1
+    return signals
+
+
+def compute_shap_values(model: XGBClassifier, X: pd.DataFrame) -> pd.DataFrame:
+    """Compute SHAP values for interpretability (optional)."""
+    try:
+        import shap
+    except ImportError as exc:  # pragma: no cover - missing optional dep
+        raise ImportError("shap is required to compute SHAP values") from exc
+    explainer = shap.TreeExplainer(model)
+    values = explainer.shap_values(X)
+    return pd.DataFrame(values, index=X.index, columns=X.columns)

--- a/portfolio_dashboard/train_model.py
+++ b/portfolio_dashboard/train_model.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+"""Command line utility to train the XGBoost model and generate signals."""
+
+import argparse
+import pandas as pd
+
+from .model_utils import (
+    prepare_features,
+    train_xgb_classifier,
+    save_model,
+    generate_signals,
+    compute_shap_values,
+)
+
+
+def load_dataset(path: str) -> pd.DataFrame:
+    """Load features dataset from CSV or Parquet."""
+    if path.endswith(".csv"):
+        df = pd.read_csv(path, parse_dates=["Date"], index_col=["Date", "Ticker"])
+    else:
+        df = pd.read_parquet(path)
+        if not isinstance(df.index, pd.MultiIndex):
+            df.set_index(["Date", "Ticker"], inplace=True)
+    return df
+
+
+def main(args: argparse.Namespace) -> None:
+    df = load_dataset(args.data)
+    X, y = prepare_features(df)
+
+    model = train_xgb_classifier(X, y)
+
+    probs = pd.Series(model.predict_proba(X)[:, 1], index=X.index, name="prob_up")
+    signals = generate_signals(probs)
+    signals.to_csv(args.pred_out)
+
+    save_model(model, args.model_out)
+
+    if args.shap_out:
+        shap_df = compute_shap_values(model, X)
+        shap_df.to_csv(args.shap_out)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    parser = argparse.ArgumentParser(description="Train XGBoost model")
+    parser.add_argument("--data", required=True, help="Path to feature dataset")
+    parser.add_argument(
+        "--model-out", default="xgb_model.pkl", help="File to save trained model"
+    )
+    parser.add_argument(
+        "--pred-out", default="predictions.csv", help="File to save predictions"
+    )
+    parser.add_argument(
+        "--shap-out",
+        default=None,
+        help="Optional path to write shap values as CSV",
+    )
+    main(parser.parse_args())

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ seaborn
 plotly
 ta
 jupyter
+shap


### PR DESCRIPTION
## Summary
- introduce config for model parameters
- implement model_utils with training and signal helpers
- add `train_model.py` CLI to train XGBoost classifier
- expose training functions from package
- document training step in README
- add `shap` to requirements

## Testing
- `python -m portfolio_dashboard.pipeline` *(fails: connect tunnel failed)*
- `python -m portfolio_dashboard.train_model --data tmp_features.csv --model-out tmp_model.pkl --pred-out tmp_predictions.csv`

------
https://chatgpt.com/codex/tasks/task_e_6862e011f8f8832d9845366c939541d3