### PR TITLE
Add backtesting engine and options module

### DIFF
--- a/portfolio_dashboard/__init__.py
+++ b/portfolio_dashboard/__init__.py
@@ -8,3 +8,10 @@ from .model_utils import (
     save_model,
     load_model,
 )
+from .backtest import run_backtest, BacktestResult
+from .options_utils import (
+    black_scholes_price,
+    option_greeks,
+    implied_volatility,
+    OptionGreeks,
+)

--- a/portfolio_dashboard/backtest.py
+++ b/portfolio_dashboard/backtest.py
@@ -1,0 +1,89 @@
+"""Simple backtesting engine for weekly long/short strategies."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+import numpy as np
+import pandas as pd
+
+from .portfolio import equal_weight_signals
+from .risk_management import (
+    sector_neutral_weights,
+    volatility_target,
+    stop_loss_signals,
+)
+
+
+@dataclass
+class BacktestResult:
+    equity_curve: pd.Series
+    trades: pd.DataFrame
+    stats: Dict[str, float]
+
+
+def run_backtest(
+    prices: pd.DataFrame,
+    signals: pd.DataFrame,
+    sectors: Dict[str, str],
+    target_vol: float = 0.1,
+    transaction_cost: float = 0.001,
+    stop_loss_pct: float = 0.1,
+) -> BacktestResult:
+    """Run a vectorized backtest with basic risk controls."""
+    if not isinstance(prices.index, pd.DatetimeIndex):
+        prices = prices.copy()
+        prices.index = pd.to_datetime(prices.index)
+    signals = signals.reindex(prices.index).fillna(0)
+
+    returns = prices.pct_change().dropna()
+    tickers = returns.columns
+
+    weights = pd.DataFrame(index=signals.index, columns=tickers, data=0.0)
+    entry_prices: Dict[str, float] = {}
+
+    equity = [1.0]
+    trade_records = []
+    prev_weights = pd.Series(0.0, index=tickers)
+
+    for i in range(len(returns.index) - 1):
+        date = returns.index[i]
+        next_date = returns.index[i + 1]
+        signal = signals.loc[date]
+        w = equal_weight_signals(signal)
+        w = sector_neutral_weights(w, sectors)
+        w = pd.Series(w, index=tickers).fillna(0.0)
+
+        # stop loss based on previous week's close
+        w = stop_loss_signals(prices.loc[date], entry_prices, w.to_dict(), stop_loss_pct)
+        w = pd.Series(w, index=tickers).fillna(0.0)
+
+        hist_rets = pd.Series(equity).pct_change().dropna()
+        scale = volatility_target(hist_rets, target_vol) if len(hist_rets) > 5 else 1.0
+        w = w * scale
+
+        weights.loc[date] = w
+        turnover = (w - prev_weights).abs().sum()
+        trade_records.append({'Date': date, 'turnover': turnover})
+
+        port_ret = (prev_weights * returns.loc[date]).sum()
+        new_equity = equity[-1] * (1 + port_ret) - turnover * transaction_cost
+        equity.append(new_equity)
+
+        # update entry prices for new positions
+        for t in tickers:
+            if prev_weights[t] == 0 and w[t] != 0:
+                entry_prices[t] = prices.loc[date, t]
+            if w[t] == 0:
+                entry_prices.pop(t, None)
+
+        prev_weights = w
+
+    equity_curve = pd.Series(equity[1:], index=returns.index[:-1])
+    stats = {
+        'sharpe': float(np.sqrt(52) * equity_curve.pct_change().mean() / equity_curve.pct_change().std()),
+        'max_drawdown': float((equity_curve.cummax() - equity_curve).max() / equity_curve.cummax().max()),
+        'turnover': float(np.mean([r['turnover'] for r in trade_records])),
+    }
+    trades = pd.DataFrame(trade_records)
+    return BacktestResult(equity_curve, trades, stats)

--- a/portfolio_dashboard/options_dashboard.py
+++ b/portfolio_dashboard/options_dashboard.py
@@ -1,0 +1,70 @@
+"""Streamlit app for single-contract options analysis."""
+from __future__ import annotations
+
+import pandas as pd
+import numpy as np
+import streamlit as st
+import yfinance as yf
+
+from .options_utils import black_scholes_price, option_greeks, implied_volatility
+
+
+def load_option_chain(ticker: str, expiry: str) -> pd.DataFrame:
+    """Fetch option chain for ticker and expiry."""
+    data = yf.Ticker(ticker)
+    chain = data.option_chain(expiry)
+    calls = chain.calls.assign(option_type='call')
+    puts = chain.puts.assign(option_type='put')
+    return pd.concat([calls, puts])
+
+
+def main() -> None:
+    st.title("Options Valuation")
+
+    ticker = st.text_input("Ticker", "AAPL")
+    if not ticker:
+        st.stop()
+
+    tk = yf.Ticker(ticker)
+    expiries = tk.options
+    if not expiries:
+        st.error("No option expiries found")
+        st.stop()
+
+    expiry = st.selectbox("Expiry", expiries)
+    chain = load_option_chain(ticker, expiry)
+
+    option_type = st.selectbox("Call/Put", ["call", "put"])
+    strikes = chain.loc[chain["option_type"] == option_type, "strike"].unique()
+    strike = st.selectbox("Strike", sorted(strikes))
+
+    row = chain[(chain["option_type"] == option_type) & (chain["strike"] == strike)].iloc[0]
+    market_price = row["lastPrice"]
+    iv_chain = row["impliedVolatility"]
+
+    spot = tk.history(period="1d")["Close"][0]
+    T = (pd.to_datetime(expiry) - pd.Timestamp.today()).days / 365
+
+    r = st.number_input("Risk-free rate", value=0.03)
+    q = st.number_input("Dividend yield", value=0.0)
+    iv = st.number_input("Implied volatility", value=float(iv_chain))
+
+    bs_price = black_scholes_price(spot, strike, T, r, iv, q, option_type)
+    greeks = option_greeks(spot, strike, T, r, iv, q, option_type)
+
+    st.subheader("Results")
+    st.write("Market price:", market_price)
+    st.write("Black-Scholes price:", round(bs_price, 4))
+    st.write(greeks)
+
+    user_price = st.number_input("Input market price to solve IV", value=float(market_price))
+    if user_price:
+        iv_est = implied_volatility(user_price, spot, strike, T, r, q, option_type)
+        if not np.isnan(iv_est):
+            st.write("Implied volatility from price:", round(iv_est, 4))
+        else:
+            st.write("Could not solve for implied volatility")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/portfolio_dashboard/options_utils.py
+++ b/portfolio_dashboard/options_utils.py
@@ -1,0 +1,100 @@
+"""Black-Scholes pricing utilities and Greek calculations."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+import numpy as np
+from scipy.stats import norm
+from scipy.optimize import brentq
+
+
+@dataclass
+class OptionGreeks:
+    delta: float
+    gamma: float
+    theta: float
+    vega: float
+    rho: float
+
+
+def _d1(S: float, K: float, T: float, r: float, sigma: float, q: float) -> float:
+    return (np.log(S / K) + (r - q + 0.5 * sigma ** 2) * T) / (sigma * np.sqrt(T))
+
+
+def _d2(d1: float, sigma: float, T: float) -> float:
+    return d1 - sigma * np.sqrt(T)
+
+
+def black_scholes_price(
+    S: float,
+    K: float,
+    T: float,
+    r: float,
+    sigma: float,
+    q: float = 0.0,
+    option_type: str = "call",
+) -> float:
+    """Return the Black-Scholes price for a call or put option."""
+    d1 = _d1(S, K, T, r, sigma, q)
+    d2 = _d2(d1, sigma, T)
+    if option_type == "call":
+        price = np.exp(-q * T) * S * norm.cdf(d1) - K * np.exp(-r * T) * norm.cdf(d2)
+    else:
+        price = K * np.exp(-r * T) * norm.cdf(-d2) - np.exp(-q * T) * S * norm.cdf(-d1)
+    return float(price)
+
+
+def option_greeks(
+    S: float,
+    K: float,
+    T: float,
+    r: float,
+    sigma: float,
+    q: float = 0.0,
+    option_type: str = "call",
+) -> OptionGreeks:
+    """Return Delta, Gamma, Theta, Vega, Rho as an ``OptionGreeks`` object."""
+    d1 = _d1(S, K, T, r, sigma, q)
+    d2 = _d2(d1, sigma, T)
+    if option_type == "call":
+        delta = np.exp(-q * T) * norm.cdf(d1)
+        theta = (
+            -S * norm.pdf(d1) * sigma * np.exp(-q * T) / (2 * np.sqrt(T))
+            - r * K * np.exp(-r * T) * norm.cdf(d2)
+            + q * S * np.exp(-q * T) * norm.cdf(d1)
+        )
+        rho = K * T * np.exp(-r * T) * norm.cdf(d2)
+    else:
+        delta = -np.exp(-q * T) * norm.cdf(-d1)
+        theta = (
+            -S * norm.pdf(d1) * sigma * np.exp(-q * T) / (2 * np.sqrt(T))
+            + r * K * np.exp(-r * T) * norm.cdf(-d2)
+            - q * S * np.exp(-q * T) * norm.cdf(-d1)
+        )
+        rho = -K * T * np.exp(-r * T) * norm.cdf(-d2)
+    gamma = norm.pdf(d1) * np.exp(-q * T) / (S * sigma * np.sqrt(T))
+    vega = S * np.exp(-q * T) * norm.pdf(d1) * np.sqrt(T)
+    return OptionGreeks(float(delta), float(gamma), float(theta), float(vega), float(rho))
+
+
+def implied_volatility(
+    market_price: float,
+    S: float,
+    K: float,
+    T: float,
+    r: float,
+    q: float = 0.0,
+    option_type: str = "call",
+    max_iter: int = 100,
+) -> float:
+    """Solve for the implied volatility from a market price."""
+
+    def objective(sigma: float) -> float:
+        return black_scholes_price(S, K, T, r, sigma, q, option_type) - market_price
+
+    try:
+        vol = brentq(objective, 1e-6, 5.0, maxiter=max_iter)
+    except Exception:
+        vol = np.nan
+    return float(vol)

--- a/portfolio_dashboard/portfolio.py
+++ b/portfolio_dashboard/portfolio.py
@@ -1,0 +1,52 @@
+"""Position and weighting utilities for strategy backtesting."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable
+
+import pandas as pd
+
+
+@dataclass
+class PortfolioState:
+    """Container for current portfolio positions."""
+
+    capital: float
+    positions: Dict[str, float] = field(default_factory=dict)  # weight by ticker
+
+
+def equal_weight_signals(signals: pd.Series) -> Dict[str, float]:
+    """Return equal-weight long/short weights from signal Series.
+
+    Parameters
+    ----------
+    signals:
+        Series of trading signals indexed by ticker. Positive for long,
+        negative for short, zero for neutral.
+
+    Returns
+    -------
+    Dict[str, float]
+        Dictionary mapping ticker to desired portfolio weight. Long and short
+        books are each scaled to 50% gross exposure so that the net exposure is
+        zero by construction.
+    """
+    longs = signals[signals > 0].index.tolist()
+    shorts = signals[signals < 0].index.tolist()
+    weights: Dict[str, float] = {}
+    if longs:
+        w = 0.5 / len(longs)
+        for t in longs:
+            weights[t] = w
+    if shorts:
+        w = -0.5 / len(shorts)
+        for t in shorts:
+            weights[t] = w
+    return weights
+
+
+def target_position_values(
+    weights: Dict[str, float], capital: float, prices: pd.Series
+) -> Dict[str, float]:
+    """Convert weight targets to notional dollar positions."""
+    return {t: capital * w for t, w in weights.items() if t in prices.index}

--- a/portfolio_dashboard/risk_management.py
+++ b/portfolio_dashboard/risk_management.py
@@ -1,0 +1,64 @@
+"""Risk management helpers for the backtesting engine."""
+from __future__ import annotations
+
+from typing import Dict
+
+import numpy as np
+import pandas as pd
+
+
+def volatility_target(
+    returns: pd.Series, target_vol: float, lookback: int = 52
+) -> float:
+    """Return scaling factor so that annualized vol matches ``target_vol``."""
+    if returns.empty:
+        return 1.0
+    recent = returns.dropna().iloc[-lookback:]
+    if recent.empty:
+        return 1.0
+    vol = recent.std() * np.sqrt(52)
+    if vol == 0:
+        return 1.0
+    return float(target_vol / vol)
+
+
+def sector_neutral_weights(
+    weights: Dict[str, float], sectors: Dict[str, str]
+) -> Dict[str, float]:
+    """Adjust weights to have zero net sector exposure."""
+    if not weights:
+        return weights
+    df = pd.DataFrame({'weight': weights})
+    df['sector'] = df.index.map(sectors)
+    sector_totals = df.groupby('sector')['weight'].sum()
+    for sector, total in sector_totals.items():
+        tickers = df[df['sector'] == sector].index
+        if len(tickers) == 0:
+            continue
+        adj = total / len(tickers)
+        for t in tickers:
+            weights[t] -= adj
+    return weights
+
+
+def stop_loss_signals(
+    current_prices: pd.Series,
+    entry_prices: Dict[str, float],
+    weights: Dict[str, float],
+    stop_pct: float,
+) -> Dict[str, float]:
+    """Close positions breaching the stop loss threshold."""
+    for t, entry in list(entry_prices.items()):
+        if t not in current_prices.index or t not in weights:
+            continue
+        price = current_prices[t]
+        w = weights[t]
+        if w == 0:
+            continue
+        ret = (price - entry) / entry
+        if w < 0:
+            ret = -ret
+        if ret <= -stop_pct:
+            weights[t] = 0.0
+            entry_prices.pop(t, None)
+    return weights

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ plotly
 ta
 jupyter
 shap
+scipy
+streamlit


### PR DESCRIPTION
## Summary
- implement modular backtesting utilities with risk controls
- add position and risk management helpers
- provide Black‑Scholes option pricing and Streamlit dashboard
- expose new functions in package init
- update requirements with scipy and streamlit

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`
- `python -m portfolio_dashboard.options_dashboard --help` *(fails: domain not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_6862e25d1f28832dbfa252eb6bae120c